### PR TITLE
feat(charts-application): add additionalEnv and useCurl

### DIFF
--- a/charts/application/Chart.yaml
+++ b/charts/application/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: MediaMarktSaturn
     url: https://github.com/MediaMarktSaturn
 appVersion: 1.0.0
-version: 1.1.0
+version: 1.2.0

--- a/charts/application/templates/_helpers.tpl
+++ b/charts/application/templates/_helpers.tpl
@@ -39,3 +39,17 @@ Selector labels
 {{ include "commonLabels" . }}
 {{ include "selectorLabels" . }}
 {{- end -}}
+
+{{/*
+    Liveness Probe using curl
+*/}}
+{{- define "liveurl" -}}
+"http://localhost:{{ .Values.container.port }}{{ .Values.livenessProbe.path }}"
+{{- end -}}
+
+{{/*
+    Readyness Probe using curl
+*/}}
+{{- define "readyurl" -}}
+"http://localhost:{{ .Values.container.port }}{{ .Values.readinessProbe.path }}"
+{{- end -}}

--- a/charts/application/templates/k8s-deployment.yaml
+++ b/charts/application/templates/k8s-deployment.yaml
@@ -64,10 +64,16 @@ spec:
             - secretRef:
                 name: {{ include "secret" . }}
             {{- end }}
-          {{- if .Values.serviceAccount.secretName }}
+          {{- if or .Values.serviceAccount.secretName .Values.additionalEnv }}
           env:
+            {{- if .Values.serviceAccount.secretName }}
             - name: "GOOGLE_APPLICATION_CREDENTIALS"
               value: "{{- .Values.serviceAccount.mountPath -}}/key.json"
+            {{- end }}
+            {{- range .Values.additionalEnv }}
+            - name: {{ .name | quote }}
+              value: {{ .value | quote }}
+            {{- end }}
           {{- end }}
           ports:
             - name: http
@@ -79,17 +85,35 @@ spec:
               protocol: {{ $ap.protocol }}
             {{- end }}
           livenessProbe:
+            {{- if .Values.livenessProbe.useCurl }}
+            exec:
+              command:
+                - curl
+                - -f
+                - -k
+                - {{ include "liveurl" . }}
+            {{ else }}
             httpGet:
               path: {{ .Values.livenessProbe.path }}
               port: {{ .Values.container.port }}
+            {{- end }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           readinessProbe:
+            {{- if .Values.readinessProbe.useCurl }}
+            exec:
+              command:
+                - curl
+                - -f
+                - -k
+                - {{ include "readyurl" . }}
+            {{ else }}
             httpGet:
               path: {{ .Values.readinessProbe.path }}
               port: {{ .Values.container.port }}
+            {{- end }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -24,6 +24,8 @@ livenessProbe:
   failureThreshold: 3
   # Number of seconds after which the probe times out.
   timeoutSeconds: 5
+  # Whether the probes should be executed by curl from inside the container ('true') or via http probes from outside ('false')
+  useCurl: false
 
 # Check if the container are able to service requests
 readinessProbe:
@@ -36,6 +38,8 @@ readinessProbe:
   failureThreshold: 3
   # Number of seconds after which the probe times out.
   timeoutSeconds: 5
+  # Whether the probes should be executed by curl from inside the container ('true') or via http probes from outside ('false')
+  useCurl: false
 
 image:
   repository: quay.io/heubeck/examiner
@@ -227,3 +231,8 @@ additionalPorts: []
 #   protocol: TCP
 #   containerPort: 8081
 #   servicePort: 81
+
+# list of additional environment variables
+additionalEnv: []
+# - name: "ktor.port"
+#   value: "8080"


### PR DESCRIPTION
Use `additionalEnv` to add extra key-value pairs to `containers.env`.

Extend `livenessProbe` and `readinessProbe` with the option `useCurl`,
to enable probe execution from inside the container.
