### PR TITLE
[Dependency-Track] Update Api-Server to 4.9.1

### DIFF
--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: MediaMarktSaturn
     url: https://github.com/MediaMarktSaturn
 appVersion: 4.9.1
-version: 1.4.1
+version: 1.4.2

--- a/charts/dependency-track/README.md
+++ b/charts/dependency-track/README.md
@@ -1,6 +1,6 @@
 # dependency-track
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.9.1](https://img.shields.io/badge/AppVersion-4.9.1-informational?style=flat-square)
+![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.9.1](https://img.shields.io/badge/AppVersion-4.9.1-informational?style=flat-square)
 
 Helm Chart for running OWASP Dependency-Track on Kubernetes
 
@@ -17,7 +17,7 @@ Helm Chart for running OWASP Dependency-Track on Kubernetes
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | apiserver.image.repository | string | `"docker.io/dependencytrack/apiserver"` |  |
-| apiserver.image.tag | string | `"4.9.0"` |  |
+| apiserver.image.tag | string | `"4.9.1"` |  |
 | apiserver.resources.limits.cpu | string | `"3"` |  |
 | apiserver.resources.limits.memory | string | `"12Gi"` |  |
 | apiserver.resources.requests.cpu | string | `"1"` |  |

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -1,7 +1,7 @@
 apiserver:
   image:
     repository: docker.io/dependencytrack/apiserver
-    tag: 4.9.0
+    tag: 4.9.1
   resources:
     limits:
       cpu: "3"


### PR DESCRIPTION
Pardon me, Dependency-Tracks API-Server and FE patch versions are independent from each other, next time, I'll wait some hours, if both bump up.