### PR TITLE
ci(actions): adapt to chart-testing-action 2.6.0

### DIFF
--- a/.github/workflows/conf/ct.yml
+++ b/.github/workflows/conf/ct.yml
@@ -4,4 +4,3 @@ chart-dirs:
 all: true
 debug: true
 check-version-increment: true
-helm-extra-args: '--timeout 120s'

--- a/.github/workflows/pr-chart-lint-and-test.yml
+++ b/.github/workflows/pr-chart-lint-and-test.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/setup-python@v4
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Lint charts
         run: ct lint --config .github/workflows/conf/ct.yml


### PR DESCRIPTION
- chore(deps): bump helm/chart-testing-action from 2.4.0 to 2.6.0
- ci(actions): remove helm-extra-args timeout
