### PR TITLE
ci(actions): fix warnings on setup helm and python

### DIFF
--- a/.github/workflows/pr-chart-lint-and-test.yml
+++ b/.github/workflows/pr-chart-lint-and-test.yml
@@ -65,8 +65,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.python_version }}
+        # with:
+        # python-version: ${{ env.python_version }}
+      - run: python --version
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.0

--- a/.github/workflows/pr-chart-lint-and-test.yml
+++ b/.github/workflows/pr-chart-lint-and-test.yml
@@ -33,6 +33,10 @@ jobs:
             **/*.md
             .github/**
 
+      - run: |
+          echo "Has changes: ${{ steps.changed-files.outputs.any_changed }}"
+          echo "Changed files: ${{ steps.changed-files.outputs.all_changed_files }}"
+
   test:
     runs-on: ubuntu-latest
     needs: prep_job

--- a/.github/workflows/pr-chart-lint-and-test.yml
+++ b/.github/workflows/pr-chart-lint-and-test.yml
@@ -29,9 +29,8 @@ jobs:
             **/*.yaml
             **/*.yml
             **/*.tpl
-          files_ignore: |
-            **/*.md
-            .github/**
+            !**/.*md
+            !.github/**
 
       - run: |
           echo "Has changes: ${{ steps.changed-files.outputs.any_changed }}"

--- a/.github/workflows/pr-chart-lint-and-test.yml
+++ b/.github/workflows/pr-chart-lint-and-test.yml
@@ -62,7 +62,7 @@ jobs:
 
       - uses: azure/setup-helm@v3.5
         with:
-          version: v3.12.1
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/pr-chart-lint-and-test.yml
+++ b/.github/workflows/pr-chart-lint-and-test.yml
@@ -65,9 +65,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v4
-        # with:
-        # python-version: ${{ env.python_version }}
-      - run: python --version
+        with:
+          python-version: ${{ env.python_version }}
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.0

--- a/.github/workflows/pr-chart-lint-and-test.yml
+++ b/.github/workflows/pr-chart-lint-and-test.yml
@@ -8,6 +8,10 @@ name: Lint and Test Charts
       - reopened
     branches:
       - main
+
+env:
+  python_version: '3.10'
+
 jobs:
   prep_job:
     runs-on: ubuntu-latest
@@ -57,8 +61,12 @@ jobs:
           fetch-depth: 0
 
       - uses: azure/setup-helm@v3.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.python_version }}
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.0
@@ -92,6 +100,8 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.python_version }}
 
       - name: Run checkov on each test case permutation
         run: .github/workflows/scripts/checkov-chart-linting.sh

--- a/.github/workflows/pr-chart-lint-and-test.yml
+++ b/.github/workflows/pr-chart-lint-and-test.yml
@@ -62,7 +62,7 @@ jobs:
 
       - uses: azure/setup-helm@v3.5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          version: v3.12.1
 
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Fixes warning in
- azure/setup-helm
  ```
  Error: [@octokit/auth-action] `GITHUB_TOKEN` variable is not set.
  ```
- actions/setup-python
  ```
  Neither 'python-version' nor 'python-version-file' inputs were supplied.
  ```

See for example [outputs](https://github.com/MediaMarktSaturn/helm-charts/actions/runs/6692577288/job/18182051073?pr=62) for PR #97.
![image](https://github.com/MediaMarktSaturn/helm-charts/assets/44575474/c5d8393b-a624-4d56-8d91-9b5184e65925)

Required
- https://github.com/MediaMarktSaturn/helm-charts/pull/63

because Helm and Python versions setup with this change, required chart-testing-actions >= `v2.6.0`.

Also adjust the changed files detection for ignored files changes.

See also:
- https://github.com/Azure/setup-helm
- https://github.com/actions/setup-python
