### PR TITLE
[Dependency-Track] Update to 4.10.1

### DIFF
--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -6,5 +6,5 @@ type: application
 maintainers:
   - name: MediaMarktSaturn
     url: https://github.com/MediaMarktSaturn
-appVersion: 4.10.0
-version: 1.5.0
+appVersion: 4.10.1
+version: 1.5.1

--- a/charts/dependency-track/README.md
+++ b/charts/dependency-track/README.md
@@ -1,6 +1,6 @@
 # dependency-track
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.10.0](https://img.shields.io/badge/AppVersion-4.10.0-informational?style=flat-square)
+![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.10.1](https://img.shields.io/badge/AppVersion-4.10.1-informational?style=flat-square)
 
 Helm Chart for running OWASP Dependency-Track on Kubernetes
 
@@ -17,7 +17,7 @@ Helm Chart for running OWASP Dependency-Track on Kubernetes
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | apiserver.image.repository | string | `"docker.io/dependencytrack/apiserver"` |  |
-| apiserver.image.tag | string | `"4.10.0"` |  |
+| apiserver.image.tag | string | `"4.10.1"` |  |
 | apiserver.resources.limits.cpu | string | `"3"` |  |
 | apiserver.resources.limits.memory | string | `"12Gi"` |  |
 | apiserver.resources.requests.cpu | string | `"1"` |  |

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -1,7 +1,7 @@
 apiserver:
   image:
     repository: docker.io/dependencytrack/apiserver
-    tag: 4.10.0
+    tag: 4.10.1
   resources:
     limits:
       cpu: "3"


### PR DESCRIPTION
It's an API-Server only release. Frontend stays 4.10.0
