### PR TITLE
fix(application): remove uriPrefix check in istio-virtual-service

### DIFF
--- a/charts/application/Chart.yaml
+++ b/charts/application/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: MediaMarktSaturn
     url: https://github.com/MediaMarktSaturn
 appVersion: 1.0.0
-version: 1.13.0
+version: 1.13.1

--- a/charts/application/README.md
+++ b/charts/application/README.md
@@ -1,6 +1,6 @@
 # application
 
-![Version: 1.13.0](https://img.shields.io/badge/Version-1.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.13.1](https://img.shields.io/badge/Version-1.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Generic application chart with common requirements of a typical workload.
 

--- a/charts/application/templates/istio-virtual-service.yaml
+++ b/charts/application/templates/istio-virtual-service.yaml
@@ -17,13 +17,11 @@ spec:
     - route:
         - destination:
             host: {{ .Release.Name }}
-      {{- if not (eq .Values.istio.ingress.uriPrefix "/") }}
       match:
         - uri:
             prefix: {{ .Values.istio.ingress.uriPrefix }}
       rewrite:
         uri: {{ .Values.istio.ingress.uriRewrite }}
-      {{ end }}
       timeout: {{ .Values.service.timeout }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
As there's already always a default set for the `uriPrefix`,
the if check in istio-virtual-service seems redundant
and therefore it can be removed.
