### PR TITLE
[Application] Make url rewrite with gateway api configurable

### DIFF
--- a/chart-tests/application/ci/test-gateway-api-values.yaml
+++ b/chart-tests/application/ci/test-gateway-api-values.yaml
@@ -9,7 +9,6 @@ resources:
 gatewayApi:
   enabled: true
   pathPrefix: /examine
-  stripPathPrefix: true
   gatewayRef:
     name: http-gateway
     namespace: default

--- a/charts/application/Chart.yaml
+++ b/charts/application/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: MediaMarktSaturn
     url: https://github.com/MediaMarktSaturn
 appVersion: 1.0.0
-version: 1.14.2
+version: 1.15.0

--- a/charts/application/templates/flagger-canary.yaml
+++ b/charts/application/templates/flagger-canary.yaml
@@ -64,9 +64,10 @@ spec:
     match:
       - uri:
           prefix: {{ .Values.gatewayApi.pathPrefix | quote }}
-    {{- if .Values.gatewayApi.stripPathPrefix }}
+    {{- if .Values.gatewayApi.pathPrefixRewrite }}
     rewrite:
-      uri: /
+      uri: {{ .Values.gatewayApi.pathPrefixRewrite | quote }}
+      type: ReplacePrefixMatch
     {{- end }}
     {{- end }}
     gatewayRefs:

--- a/charts/application/templates/k8s-http-route.yaml
+++ b/charts/application/templates/k8s-http-route.yaml
@@ -33,13 +33,13 @@ spec:
       - path:
           type: PathPrefix
           value: {{ .Values.gatewayApi.pathPrefix | quote }}
-      {{- if .Values.gatewayApi.stripPathPrefix }}
+      {{- if .Values.gatewayApi.pathPrefixRewrite }}
       filters:
         - type: URLRewrite
           urlRewrite:
             path:
-              replaceFullPath: /
-              type: ReplaceFullPath
+              replacePrefixMatch: {{ .Values.gatewayApi.pathPrefixRewrite | quote }}
+              type: ReplacePrefixMatch
       {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -168,8 +168,10 @@ linkerd:
 gatewayApi:
   enabled: false
   host:
+  # optional first url part to match this services http route
   pathPrefix:
-  stripPathPrefix: false
+  # optionally rewrite (or remove) the matched url prefix
+  pathPrefixRewrite: /
   gatewayRef:
     name:
     namespace:


### PR DESCRIPTION
This looks like a breaking change, in fact it isn't.
The strip path prefix did never work as intended, because it stripped not only the (matched) prefix, but the entire path, making every request hit the service at `/`.
Beside that this behavior was crap, the new default that match path prefixes are stripped is what was intended before.