### PR TITLE
Add optional k8s role binding to application chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 .tmp
 .chckv
 charts/*/ci
+helm-docs

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@
 .tmp
 .chckv
 charts/*/ci
-helm-docs

--- a/chart-tests/application/ci/test-init-container-values.yaml
+++ b/chart-tests/application/ci/test-init-container-values.yaml
@@ -17,7 +17,7 @@ initContainers:
       tag: 9.3
     command: ['sh', '-c', 'echo $BUMP_ME_UP']
     env:
-     BUMP_ME_UP: bump me up
+      BUMP_ME_UP: bump me up
     securityContext:
       runAsNonRoot: true
       allowPrivilegeEscalation: false

--- a/chart-tests/application/ci/test-role-binding-values.yaml
+++ b/chart-tests/application/ci/test-role-binding-values.yaml
@@ -1,0 +1,8 @@
+serviceAccount:
+  rbac:
+    - kind: RoleBinding
+      roleType: Role
+      roleName: admin
+    - kind: ClusterRoleBinding
+      roleType: ClusterRole
+      roleName: edit

--- a/chart-tests/application/ci/test-role-binding-values.yaml
+++ b/chart-tests/application/ci/test-role-binding-values.yaml
@@ -6,3 +6,6 @@ serviceAccount:
     - kind: ClusterRoleBinding
       roleType: ClusterRole
       roleName: edit
+    - kind: ClusterRoleBinding
+      roleType: ClusterRole
+      roleName: view

--- a/charts/application/Chart.yaml
+++ b/charts/application/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: MediaMarktSaturn
     url: https://github.com/MediaMarktSaturn
 appVersion: 1.0.0
-version: 1.16.0
+version: 1.17.0

--- a/charts/application/Chart.yaml
+++ b/charts/application/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: MediaMarktSaturn
     url: https://github.com/MediaMarktSaturn
 appVersion: 1.0.0
-version: 1.17.0
+version: 1.18.0

--- a/charts/application/README.md
+++ b/charts/application/README.md
@@ -1,6 +1,6 @@
 # application
 
-![Version: 1.16.0](https://img.shields.io/badge/Version-1.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.17.0](https://img.shields.io/badge/Version-1.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Generic application chart with common requirements of a typical workload.
 
@@ -71,6 +71,7 @@ Generic application chart with common requirements of a typical workload.
 | serviceAccount.secretName | string | `nil` |  |
 | serviceAccount.mountPath | string | `"/config/service-account"` |  |
 | serviceAccount.automountServiceAccountToken | bool | `false` |  |
+| serviceAccount.rbac | list | `[]` |  |
 | istio.enabled | bool | `false` |  |
 | istio.tlsMode | string | `"ISTIO_MUTUAL"` |  |
 | istio.ingress.enabled | bool | `true` |  |

--- a/charts/application/templates/k8s-rolebinding.yaml
+++ b/charts/application/templates/k8s-rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- range .Values.serviceAccount.rbac }}
+{{- if or (eq .kind "RoleBinding") (eq .kind "ClusterRoleBinding") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ .kind }}
+metadata:
+  name: {{ $.Release.Name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ .roleType }}
+  name: {{ .roleName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $.Release.Name }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/application/templates/k8s-rolebinding.yaml
+++ b/charts/application/templates/k8s-rolebinding.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ .kind }}
 metadata:
-  name: {{ $.Release.Name }}
+  name: {{ printf "%s-%s" .roleName $.Release.Name | quote }}
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "labels" $ | nindent 4 }}

--- a/charts/application/templates/k8s-rolebinding.yaml
+++ b/charts/application/templates/k8s-rolebinding.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ .kind }}
 metadata:
-  name: {{ printf "%s-%s" .roleName $.Release.Name | quote }}
+  name: {{ printf "%s-%s" $.Release.Name .roleName | quote }}
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "labels" $ | nindent 4 }}

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -141,6 +141,11 @@ serviceAccount:
   mountPath: /config/service-account
   # k8s ServiceAccount.automountServiceAccountToken setting
   automountServiceAccountToken: false
+  # gives the application the defined role binding
+  rbac: []
+  #  - kind: RoleBinding
+  #    roleType: ClusterRole
+  #    roleName: admin
 
 # Pick one of the service mesh configs
 istio:


### PR DESCRIPTION
We have multiple applications that require access to the k8s API.
It would be great to have this as an option.