### PR TITLE
Allow for service, readinessProbe and livenessProbe to be disabled

### DIFF
--- a/.github/workflows/conf/checkov.yml
+++ b/.github/workflows/conf/checkov.yml
@@ -16,3 +16,5 @@ skip-check:
   - CKV2_K8S_6 # https://www.checkov.io/5.Policy%20Index/kubernetes.html - Minimize the admission of pods which lack an associated NetworkPolicy
   - CKV_K8S_13 # https://docs.bridgecrew.io/docs/bc_k8s_12 - Ensure memory limits are set
   - CKV_K8S_11 # https://docs.bridgecrew.io/docs/bc_k8s_10 - Ensure CPU limits are set
+  - CKV_K8S_8 # https://docs.prismacloud.io/en/enterprise-edition/policy-reference/kubernetes-policies/kubernetes-policy-index/bc-k8s-7 - Ensure liveness probes are implemented
+  - CKV_K8S_9 # https://docs.prismacloud.io/en/enterprise-edition/policy-reference/kubernetes-policies/kubernetes-policy-index/bc-k8s-8 - Ensure readiness probes are implemented

--- a/chart-tests/application/ci/test-disabled-service-values.yaml
+++ b/chart-tests/application/ci/test-disabled-service-values.yaml
@@ -1,0 +1,6 @@
+service:
+  enabled: false
+readinessProbe:
+  enabled: false
+livenessProbe:
+  enabled: false

--- a/chart-tests/application/ci/test-disabled-service.yaml
+++ b/chart-tests/application/ci/test-disabled-service.yaml
@@ -1,0 +1,6 @@
+service:
+  disabled: true
+readinessProbe:
+  disabled: true
+livenessProbe:
+  disabled: true

--- a/chart-tests/application/ci/test-disabled-service.yaml
+++ b/chart-tests/application/ci/test-disabled-service.yaml
@@ -1,6 +1,0 @@
-service:
-  disabled: true
-readinessProbe:
-  disabled: true
-livenessProbe:
-  disabled: true

--- a/charts/application/Chart.yaml
+++ b/charts/application/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: MediaMarktSaturn
     url: https://github.com/MediaMarktSaturn
 appVersion: 1.0.0
-version: 1.18.0
+version: 1.19.0

--- a/charts/application/README.md
+++ b/charts/application/README.md
@@ -1,6 +1,6 @@
 # application
 
-![Version: 1.18.0](https://img.shields.io/badge/Version-1.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.19.0](https://img.shields.io/badge/Version-1.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Generic application chart with common requirements of a typical workload.
 
@@ -24,12 +24,14 @@ Generic application chart with common requirements of a typical workload.
 | autoscaling.minReplicaCount | int | `1` |  |
 | autoscaling.maxReplicaCount | int | `1` |  |
 | autoscaling.averageUtilization.cpu | int | `80` |  |
+| livenessProbe.disabled | bool | `false` |  |
 | livenessProbe.path | string | `"/.well-known/live"` |  |
 | livenessProbe.cmd | list | `[]` |  |
 | livenessProbe.initialDelaySeconds | int | `10` |  |
 | livenessProbe.periodSeconds | int | `10` |  |
 | livenessProbe.failureThreshold | int | `3` |  |
 | livenessProbe.timeoutSeconds | int | `5` |  |
+| readinessProbe.disabled | bool | `false` |  |
 | readinessProbe.path | string | `"/.well-known/ready"` |  |
 | readinessProbe.cmd | list | `[]` |  |
 | readinessProbe.initialDelaySeconds | int | `10` |  |
@@ -49,6 +51,7 @@ Generic application chart with common requirements of a typical workload.
 | image.repositoryProvider | string | `"generic"` |  |
 | image.imageAutomationNamespace | string | `nil` |  |
 | image.pullSecrets | list | `[]` |  |
+| service.disabled | bool | `false` |  |
 | service.port | int | `80` |  |
 | service.timeout | string | `"120s"` |  |
 | service.annotations | object | `{}` |  |

--- a/charts/application/README.md
+++ b/charts/application/README.md
@@ -24,14 +24,14 @@ Generic application chart with common requirements of a typical workload.
 | autoscaling.minReplicaCount | int | `1` |  |
 | autoscaling.maxReplicaCount | int | `1` |  |
 | autoscaling.averageUtilization.cpu | int | `80` |  |
-| livenessProbe.disabled | bool | `false` |  |
+| livenessProbe.enabled | bool | `true` |  |
 | livenessProbe.path | string | `"/.well-known/live"` |  |
 | livenessProbe.cmd | list | `[]` |  |
 | livenessProbe.initialDelaySeconds | int | `10` |  |
 | livenessProbe.periodSeconds | int | `10` |  |
 | livenessProbe.failureThreshold | int | `3` |  |
 | livenessProbe.timeoutSeconds | int | `5` |  |
-| readinessProbe.disabled | bool | `false` |  |
+| readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.path | string | `"/.well-known/ready"` |  |
 | readinessProbe.cmd | list | `[]` |  |
 | readinessProbe.initialDelaySeconds | int | `10` |  |
@@ -51,7 +51,7 @@ Generic application chart with common requirements of a typical workload.
 | image.repositoryProvider | string | `"generic"` |  |
 | image.imageAutomationNamespace | string | `nil` |  |
 | image.pullSecrets | list | `[]` |  |
-| service.disabled | bool | `false` |  |
+| service.enabled | bool | `true` |  |
 | service.port | int | `80` |  |
 | service.timeout | string | `"120s"` |  |
 | service.annotations | object | `{}` |  |

--- a/charts/application/templates/_podTemplate.tpl
+++ b/charts/application/templates/_podTemplate.tpl
@@ -230,7 +230,7 @@ spec:
           containerPort: {{ $ap.containerPort }}
           protocol: {{ $ap.protocol }}
         {{- end }}
-      {{- if not .Values.livenessProbe.disabled }}
+      {{- if .Values.livenessProbe.enabled }}
       livenessProbe:
         {{- if .Values.livenessProbe.cmd }}
         exec:
@@ -248,7 +248,7 @@ spec:
         failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
       {{- end }}
-      {{- if not .Values.readinessProbe.disabled }}
+      {{- if .Values.readinessProbe.enabled }}
       readinessProbe:
         {{- if .Values.readinessProbe.cmd }}
         exec:

--- a/charts/application/templates/_podTemplate.tpl
+++ b/charts/application/templates/_podTemplate.tpl
@@ -230,6 +230,7 @@ spec:
           containerPort: {{ $ap.containerPort }}
           protocol: {{ $ap.protocol }}
         {{- end }}
+      {{- if not .Values.livenessProbe.disabled }}
       livenessProbe:
         {{- if .Values.livenessProbe.cmd }}
         exec:
@@ -246,6 +247,8 @@ spec:
         periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
         failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+      {{- end }}
+      {{- if not .Values.readinessProbe.disabled }}
       readinessProbe:
         {{- if .Values.readinessProbe.cmd }}
         exec:
@@ -262,6 +265,7 @@ spec:
         periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
         failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+      {{- end }}
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
       volumeMounts: {{ if not (or .Values.secretVolumes .Values.configVolumes .Values.serviceAccount.secretName .Values.encryptedSecret.mountPath .Values.volumeMounts) -}}[]{{- end -}}

--- a/charts/application/templates/k8s-service.yaml
+++ b/charts/application/templates/k8s-service.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.service.disabled) (not (and .Values.canary.enabled .Values.istio.enabled)) }}
+{{- if and .Values.service.enabled (not (and .Values.canary.enabled .Values.istio.enabled)) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/application/templates/k8s-service.yaml
+++ b/charts/application/templates/k8s-service.yaml
@@ -1,4 +1,4 @@
-{{- if not (and .Values.canary.enabled .Values.istio.enabled ) }}
+{{- if and (not .Values.service.disabled) (not (and .Values.canary.enabled .Values.istio.enabled)) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -21,8 +21,8 @@ autoscaling:
 
 # Check if the container is running
 livenessProbe:
-  # Disable the liveness probe
-  disabled: false
+  # Allows to disable the liveness probe
+  enabled: true
   path: /.well-known/live
   # Use a command to check liveness from inside the container, for example ['curl', '-f', 'http://localhost/health/live'].
   # This will take precedence over the given `path` value, if provided.
@@ -38,8 +38,8 @@ livenessProbe:
 
 # Check if the container are able to service requests
 readinessProbe:
-  # Disable the readiness probe
-  disabled: false
+  # Allows to disable the readiness probe
+  enabled: true
   path: /.well-known/ready
   # Use a command to check readiness from inside the container, for example ['curl', '-f', 'http://localhost/health/ready'].
   # This will take precedence over the given `path` value, if provided.
@@ -86,7 +86,7 @@ image:
   pullSecrets: []
 
 service:
-  disabled: false
+  enabled: true
   port: 80
   timeout: 120s
   annotations: {}

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -21,6 +21,8 @@ autoscaling:
 
 # Check if the container is running
 livenessProbe:
+  # Disable the liveness probe
+  disabled: false
   path: /.well-known/live
   # Use a command to check liveness from inside the container, for example ['curl', '-f', 'http://localhost/health/live'].
   # This will take precedence over the given `path` value, if provided.
@@ -36,6 +38,8 @@ livenessProbe:
 
 # Check if the container are able to service requests
 readinessProbe:
+  # Disable the readiness probe
+  disabled: false
   path: /.well-known/ready
   # Use a command to check readiness from inside the container, for example ['curl', '-f', 'http://localhost/health/ready'].
   # This will take precedence over the given `path` value, if provided.
@@ -82,6 +86,7 @@ image:
   pullSecrets: []
 
 service:
+  disabled: false
   port: 80
   timeout: 120s
   annotations: {}


### PR DESCRIPTION
We have services that do not expose any API and would prefer to keep them that way.
I implemented it without any breaking changes (hopefully)