### PR TITLE
[Application] add value to change the podManagementPolicy for statefulSet

### DIFF
--- a/charts/application/Chart.yaml
+++ b/charts/application/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: MediaMarktSaturn
     url: https://github.com/MediaMarktSaturn
 appVersion: 1.0.0
-version: 1.26.1
+version: 1.27.0

--- a/charts/application/templates/k8s-statefulset.yaml
+++ b/charts/application/templates/k8s-statefulset.yaml
@@ -15,6 +15,7 @@ spec:
       {{- include "selectorLabels" . | nindent 6 }}
   replicas: {{ .Values.autoscaling.minReplicaCount }}
   serviceName: {{ .Release.Name }}
+  podManagementPolicy: {{ .Values.statefulSet.podManagementPolicy }}
   template:
     {{- include "podTemplate" . | nindent 4 }}
 {{- end }}

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -2,6 +2,9 @@
 statefulSet:
   enabled: false
 
+  # The policy for how pods inside the statefulSet are created and stopped: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
+  podManagementPolicy: OrderedReady
+
 container:
   port: 8080
   securityContext:

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -2,7 +2,7 @@
 statefulSet:
   enabled: false
 
-  # The policy for how pods inside the statefulSet are created and stopped: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
+  # The policy for how pods inside the statefulSet are handled: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
   podManagementPolicy: OrderedReady
 
 container:


### PR DESCRIPTION
For an autoscaled statefulSet it is neccessary to change the podManagementPolicy to Parallel if the statefulSet is stuck with unready pods but still needs to be scaled up. By default `podManagementPolicy: OrderedReady` prevents the statefulSet to scale when unready pods are existing. This change adds the option to change the default value.

https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies