### PR TITLE
feat(action): use draft workaround for docs PRs

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -88,13 +88,15 @@ jobs:
       - name: Create PR
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: Generated Chart Docs
+          commit-message: "docs: update versions in readme"
           author: github_actions <noreply@github.com>
           delete-branch: true
-          branch: generate-chart-docs/patch
+          branch: docs/update-readme
           title: "docs: update versions in readme"
           body: |
             Update versions in README file(s) after the latest merge on main.
             :information_source: close and re-open this pull request to trigger any checks.
           add-paths: |
             *.md
+          labels: documentation
+          draft: true

--- a/.github/workflows/pr-chart-lint-and-test.yml
+++ b/.github/workflows/pr-chart-lint-and-test.yml
@@ -5,6 +5,7 @@ name: Lint and Test Charts
       - opened
       - synchronize
       - reopened
+      - ready_for_review
     branches:
       - main
 


### PR DESCRIPTION
Currently readme updating pull requests need to be closed and re-opened
to trigger the necessary checks as the default github token is used.

To simplify this process a little bit, use the draft pull request
workaround as described at
- https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs

so that there's one click less than the current setup.
