### PR TITLE
[Application] Fix securityContext for sidecars

### DIFF
--- a/charts/application/Chart.yaml
+++ b/charts/application/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: MediaMarktSaturn
     url: https://github.com/MediaMarktSaturn
 appVersion: 1.0.0
-version: 1.29.0
+version: 1.29.1

--- a/charts/application/templates/_podTemplate.tpl
+++ b/charts/application/templates/_podTemplate.tpl
@@ -63,7 +63,7 @@ spec:
         {{- end }}
       securityContext:
         {{- if and $i.securityContext $.Values.initDefaults.securityContext }}
-        {{- toYaml (mergeOverwrite $.Values.initDefaults.securityContext $i.securityContext) | nindent 8 }}
+        {{- toYaml (merge $i.securityContext $.Values.initDefaults.securityContext) | nindent 8 }}
         {{- else }}
         {{- toYaml (or $i.securityContext $.Values.initDefaults.securityContext) | nindent 8 }}
         {{- end }}

--- a/charts/application/templates/_podTemplate.tpl
+++ b/charts/application/templates/_podTemplate.tpl
@@ -127,7 +127,7 @@ spec:
         {{- end }}
       securityContext:
         {{- if and $s.securityContext $.Values.sidecarDefaults.securityContext }}
-        {{- toYaml (mergeOverwrite $.Values.sidecarDefaults.securityContext $s.securityContext) | nindent 8 }}
+        {{- toYaml (merge $s.securityContext $.Values.sidecarDefaults.securityContext) | nindent 8 }}
         {{- else }}
         {{- toYaml (or $s.securityContext $.Values.sidecarDefaults.securityContext) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
The previous implementation did override the default value which then were applied to the next sidecar if no securityContext was set for this sidecar.