### PR TITLE
[Application]: add command to container and sidecars and fix security context (again)

### DIFF
--- a/chart-tests/application/ci/test-image-lifecycle-values.yaml
+++ b/chart-tests/application/ci/test-image-lifecycle-values.yaml
@@ -10,7 +10,7 @@ image:
   tag: stable
 container:
   command: ["sh", "-c"]
-  args: ["sleep", "2000"]
+  args: ["sleep 2000"]
 lifecycle:
   postStart:
     exec:

--- a/chart-tests/application/ci/test-image-lifecycle-values.yaml
+++ b/chart-tests/application/ci/test-image-lifecycle-values.yaml
@@ -9,6 +9,7 @@ image:
   repository: busybox
   tag: stable
 container:
+  command []
   args: ["sleep", "2000"]
 lifecycle:
   postStart:

--- a/chart-tests/application/ci/test-image-lifecycle-values.yaml
+++ b/chart-tests/application/ci/test-image-lifecycle-values.yaml
@@ -9,7 +9,6 @@ image:
   repository: busybox
   tag: stable
 container:
-  command []
   args: ["sleep", "2000"]
 lifecycle:
   postStart:

--- a/chart-tests/application/ci/test-image-lifecycle-values.yaml
+++ b/chart-tests/application/ci/test-image-lifecycle-values.yaml
@@ -9,6 +9,7 @@ image:
   repository: busybox
   tag: stable
 container:
+  command: ["sh", "-c"]
   args: ["sleep", "2000"]
 lifecycle:
   postStart:

--- a/chart-tests/application/ci/test-init-container-values.yaml
+++ b/chart-tests/application/ci/test-init-container-values.yaml
@@ -32,8 +32,11 @@ initContainers:
     command: ['ls', '-lah', '/']
     env: {}
     restartPolicy: Never
-    securityContext:
-      runAsNonRoot: true
-      allowPrivilegeEscalation: false
-      runAsUser: 65534
-      runAsGroup: 65534
+
+
+initDefaults:
+  securityContext:
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
+    runAsGroup: 65534

--- a/chart-tests/application/ci/test-sidecar-values.yaml
+++ b/chart-tests/application/ci/test-sidecar-values.yaml
@@ -55,6 +55,16 @@ sidecars:
       port: 7070
     securityContext:
       runAsUser: 65532
+  - name: 
+    image:
+      repository: busybox
+      tag: stable
+    command: ["sh", "-c"]
+    args: ["sleep", "2000"]
+    livenessProbe:
+      cmd: ['ls']
+    readinessProbe:
+      cmd: ['ls']
 
 sidecarDefaults:
   resources:

--- a/chart-tests/application/ci/test-sidecar-values.yaml
+++ b/chart-tests/application/ci/test-sidecar-values.yaml
@@ -30,6 +30,7 @@ sidecars:
       port: 9090
     securityContext:
       runAsUser: 65532
+      allowPrivilegeEscalation: false
     volumeMountNames:
       - share
     ports:
@@ -55,6 +56,7 @@ sidecars:
       port: 7070
     securityContext:
       runAsUser: 65532
+      allowPrivilegeEscalation: false
   - name: commandtest
     image:
       repository: busybox
@@ -74,3 +76,6 @@ sidecarDefaults:
     limits:
       cpu: 100m
       memory: 100Mi
+  securityContext:
+    runAsNonRoot: false
+    allowPrivilegeEscalation: false

--- a/chart-tests/application/ci/test-sidecar-values.yaml
+++ b/chart-tests/application/ci/test-sidecar-values.yaml
@@ -60,7 +60,7 @@ sidecars:
       repository: busybox
       tag: stable
     command: ["sh", "-c"]
-    args: ["sleep", "2000"]
+    args: ["sleep 2000"]
     livenessProbe:
       cmd: ['ls']
     readinessProbe:

--- a/chart-tests/application/ci/test-sidecar-values.yaml
+++ b/chart-tests/application/ci/test-sidecar-values.yaml
@@ -55,7 +55,7 @@ sidecars:
       port: 7070
     securityContext:
       runAsUser: 65532
-  - name: 
+  - name: commandtest
     image:
       repository: busybox
       tag: stable

--- a/chart-tests/application/ci/test-statefulset-sidecar-values.yaml
+++ b/chart-tests/application/ci/test-statefulset-sidecar-values.yaml
@@ -33,6 +33,7 @@ sidecars:
       port: 9090
     securityContext:
       runAsUser: 65532
+      allowPrivilegeEscalation: false
     volumeMountNames:
       - share
   - name: kickback
@@ -54,6 +55,7 @@ sidecars:
       port: 7070
     securityContext:
       runAsUser: 65532
+      allowPrivilegeEscalation: false
 
 sidecarDefaults:
   resources:

--- a/charts/application/Chart.yaml
+++ b/charts/application/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: MediaMarktSaturn
     url: https://github.com/MediaMarktSaturn
 appVersion: 1.0.0
-version: 1.29.1
+version: 1.30.0

--- a/charts/application/templates/_podTemplate.tpl
+++ b/charts/application/templates/_podTemplate.tpl
@@ -121,7 +121,7 @@ spec:
       image: "{{ .image.repository }}:{{ .image.tag }}"
       {{- end }}
       imagePullPolicy: {{ or $s.image.pullPolicy $.Values.sidecarDefaults.image.pullPolicy }}
-      {{ if $s.command }} 
+      {{- if $s.command }} 
       command: 
         {{- with (first $s.command ) }}
         - {{ . | quote }}
@@ -260,7 +260,7 @@ spec:
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
       {{- end }}
       imagePullPolicy: {{ .Values.image.pullPolicy }}
-      {{ if .Values.container.command }} 
+      {{- if .Values.container.command }} 
       command: 
         {{- with (first .Values.container.command ) }}
         - {{ . | quote }}

--- a/charts/application/templates/_podTemplate.tpl
+++ b/charts/application/templates/_podTemplate.tpl
@@ -121,10 +121,12 @@ spec:
       image: "{{ .image.repository }}:{{ .image.tag }}"
       {{- end }}
       imagePullPolicy: {{ or $s.image.pullPolicy $.Values.sidecarDefaults.image.pullPolicy }}
-      command: {{ if not $s.command }}[]{{ end }}
+      {{ if $s.command }} 
+      command: 
         {{- with (first $s.command ) }}
         - {{ . | quote }}
         {{- end }}
+      {{- end }}  
       args: {{ if not $s.args }}[]{{ end }}
         {{- range $s.args }}
         - {{ . | quote }}
@@ -258,8 +260,9 @@ spec:
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
       {{- end }}
       imagePullPolicy: {{ .Values.image.pullPolicy }}
-      command: {{ if not .Values.container.command }}[]{{ end }}
-        {{- with ( first .Values.container.command ) }}
+      {{ if .Values.container.command }} 
+      command: 
+        {{- with (first .Values.container.command ) }}
         - {{ . | quote }}
         {{- end }}
       args: {{ if not .Values.container.args }}[]{{ end }}

--- a/charts/application/templates/_podTemplate.tpl
+++ b/charts/application/templates/_podTemplate.tpl
@@ -121,6 +121,10 @@ spec:
       image: "{{ .image.repository }}:{{ .image.tag }}"
       {{- end }}
       imagePullPolicy: {{ or $s.image.pullPolicy $.Values.sidecarDefaults.image.pullPolicy }}
+      command: {{ if not $s.command }}[]{{ end }}
+        {{- with (first $s.command ) }}
+        - {{ . | quote }}
+        {{- end }}
       args: {{ if not $s.args }}[]{{ end }}
         {{- range $s.args }}
         - {{ . | quote }}
@@ -254,6 +258,10 @@ spec:
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
       {{- end }}
       imagePullPolicy: {{ .Values.image.pullPolicy }}
+      command: {{ if not .Values.container.command }}[]{{ end }}
+        {{- with ( first .Values.container.command ) }}
+        - {{ . | quote }}
+        {{- end }}
       args: {{ if not .Values.container.args }}[]{{ end }}
         {{- range .Values.container.args }}
         - {{ . | quote }}

--- a/charts/application/templates/_podTemplate.tpl
+++ b/charts/application/templates/_podTemplate.tpl
@@ -123,7 +123,7 @@ spec:
       imagePullPolicy: {{ or $s.image.pullPolicy $.Values.sidecarDefaults.image.pullPolicy }}
       {{- if $s.command }} 
       command: 
-        {{- with (first $s.command ) }}
+        {{- range $s.command }}
         - {{ . | quote }}
         {{- end }}
       {{- end }}  
@@ -262,7 +262,7 @@ spec:
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       {{- if .Values.container.command }} 
       command: 
-        {{- with (first .Values.container.command ) }}
+        {{- range .Values.container.command }}
         - {{ . | quote }}
         {{- end }}
       {{- end }}

--- a/charts/application/templates/_podTemplate.tpl
+++ b/charts/application/templates/_podTemplate.tpl
@@ -265,6 +265,7 @@ spec:
         {{- with (first .Values.container.command ) }}
         - {{ . | quote }}
         {{- end }}
+      {{- end }}
       args: {{ if not .Values.container.args }}[]{{ end }}
         {{- range .Values.container.args }}
         - {{ . | quote }}

--- a/charts/application/templates/_podTemplate.tpl
+++ b/charts/application/templates/_podTemplate.tpl
@@ -62,11 +62,7 @@ spec:
         - {{ . | quote }}
         {{- end }}
       securityContext:
-        {{- if and $i.securityContext $.Values.initDefaults.securityContext }}
-        {{- toYaml (merge $i.securityContext $.Values.initDefaults.securityContext) | nindent 8 }}
-        {{- else }}
-        {{- toYaml (or $i.securityContext $.Values.initDefaults.securityContext) | nindent 8 }}
-        {{- end }}
+        {{- toYaml (default $.Values.initDefaults.securityContext $i.securityContext ) | nindent 8 }}
       resources:
         {{- toYaml (or $i.resources $.Values.initDefaults.resources) | nindent 8 }}
       env:
@@ -132,11 +128,7 @@ spec:
         - {{ . | quote }}
         {{- end }}
       securityContext:
-        {{- if and $s.securityContext $.Values.sidecarDefaults.securityContext }}
-        {{- toYaml (merge $s.securityContext $.Values.sidecarDefaults.securityContext) | nindent 8 }}
-        {{- else }}
-        {{- toYaml (or $s.securityContext $.Values.sidecarDefaults.securityContext) | nindent 8 }}
-        {{- end }}
+        {{- toYaml (default $.Values.sidecarDefaults.securityContext $s.securityContext) | nindent 8 }}
       resources:
         {{- toYaml (or $s.resources $.Values.sidecarDefaults.resources) | nindent 8 }}
       env:

--- a/charts/application/templates/_podTemplate.tpl
+++ b/charts/application/templates/_podTemplate.tpl
@@ -117,12 +117,12 @@ spec:
       image: "{{ .image.repository }}:{{ .image.tag }}"
       {{- end }}
       imagePullPolicy: {{ or $s.image.pullPolicy $.Values.sidecarDefaults.image.pullPolicy }}
-      {{- if $s.command }} 
-      command: 
+      {{- if $s.command }}
+      command:
         {{- range $s.command }}
         - {{ . | quote }}
         {{- end }}
-      {{- end }}  
+      {{- end }}
       args: {{ if not $s.args }}[]{{ end }}
         {{- range $s.args }}
         - {{ . | quote }}
@@ -252,8 +252,8 @@ spec:
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
       {{- end }}
       imagePullPolicy: {{ .Values.image.pullPolicy }}
-      {{- if .Values.container.command }} 
-      command: 
+      {{- if .Values.container.command }}
+      command:
         {{- range .Values.container.command }}
         - {{ . | quote }}
         {{- end }}

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -13,7 +13,7 @@ container:
   annotations:
     "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
   # arguments given to the container; []one string
-  command: []
+  # command: []
   # arguments given to the container; []string
   args: []
 

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -12,6 +12,8 @@ container:
   # annotations to be added to the pod template
   annotations:
     "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
+  # arguments given to the container; []one string
+  command: []
   # arguments given to the container; []string
   args: []
 
@@ -342,6 +344,7 @@ sidecars: []
 #   image:
 #     repository: quay.io/heubeck/examiner
 #     tag: 1.13.3
+#   coammnd: []
 #   args: []
 #   env: {}
 #   configEnvFrom: []

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -12,8 +12,8 @@ container:
   # annotations to be added to the pod template
   annotations:
     "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
-  # arguments given to the container; []one string
-  # command: []
+  # command line given to the container; []string
+  command: []
   # arguments given to the container; []string
   args: []
 

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -344,7 +344,7 @@ sidecars: []
 #   image:
 #     repository: quay.io/heubeck/examiner
 #     tag: 1.13.3
-#   coammnd: []
+#   command: []
 #   args: []
 #   env: {}
 #   configEnvFrom: []

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -428,6 +428,7 @@ initDefaults:
       cpu: 500m
       memory: 100Mi
   restartPolicy: Always
+  # securityContext: {}
 
 # List of tolerations, will be taken over like-for-like to pod-spec
 tolerations: []


### PR DESCRIPTION
We trapped into https://github.com/helm/helm/issues/5238 with the merge of default security context with specific ones in sidecar or initcontainer.

objects seem to be merged by using the `or` operation - effectively making `true` always the result for bool properties.

with this change, behavior changes, but as it was already wrong in the past it just can get better.
