### PR TITLE
chore(ci): bump python version from 3.10 to 3.13

### DIFF
--- a/.github/workflows/pr-chart-lint-and-test.yml
+++ b/.github/workflows/pr-chart-lint-and-test.yml
@@ -1,3 +1,4 @@
+---
 name: Lint and Test Charts
 "on":
   pull_request:
@@ -10,7 +11,7 @@ name: Lint and Test Charts
       - main
 
 env:
-  python_version: '3.10'
+  python_version: '3.13'
 
 jobs:
   prep_job:


### PR DESCRIPTION
Upgrade to the current LTS version. See also:
- https://devguide.python.org/versions/
