### PR TITLE
chore(actions): pin sha hash instead of version

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -21,13 +21,13 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
 
       - name: Generate docs
         run: .github/workflows/scripts/helm-docs.sh
 
       - name: Publish charts
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           charts_dir: charts
           charts_repo_url: https://helm-charts.mms.tech
@@ -41,7 +41,7 @@ jobs:
     needs:
       - release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           ref: gh-pages
@@ -50,7 +50,7 @@ jobs:
         run: git checkout origin/main -- README.md
 
       - name: Generate index.html from readme.md
-        uses: jaywcjlove/markdown-to-html-cli@v5.0.3
+        uses: jaywcjlove/markdown-to-html-cli@d2c8ffd676de1801e2586904bc540a938e4bc480 # v5.0.3
         with:
           source: README.md
           output: index.html
@@ -78,7 +78,7 @@ jobs:
     name: Generate helm docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -86,7 +86,7 @@ jobs:
         run: .github/workflows/scripts/helm-docs.sh
 
       - name: Create PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           commit-message: "docs: update versions in readme"
           author: github_actions <noreply@github.com>

--- a/.github/workflows/pr-chart-lint-and-test.yml
+++ b/.github/workflows/pr-chart-lint-and-test.yml
@@ -20,11 +20,11 @@ jobs:
       has_changes: ${{ steps.changed-files.outputs.any_changed }}
       matrix: ${{ steps.result.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
-      - uses: tj-actions/changed-files@v46
+      - uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         id: changed-files
         with:
           files: |
@@ -66,25 +66,25 @@ jobs:
       matrix: ${{ fromJson(needs.prep_job.outputs.matrix) }}
     name: ${{ matrix.name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: ${{ env.python_version }}
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.7.0
+        uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
 
       - name: Lint charts
         run: ct lint --config .github/workflows/conf/ct-lint.yml
 
-      - uses: helm/kind-action@main
+      - uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
           config: .github/workflows/conf/kind.yml
           version: ${{ env.kind_version }}
@@ -105,11 +105,11 @@ jobs:
     needs: prep_job
     if: ${{ needs.prep_job.outputs.has_changes == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: ${{ env.python_version }}
 

--- a/.github/workflows/scripts/chart-test-prep.sh
+++ b/.github/workflows/scripts/chart-test-prep.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "::debug::install flux crds"
+echo "[INFO] install flux crds"
 mkdir -p .tmp
 curl -s https://raw.githubusercontent.com/fluxcd/flux2/main/manifests/crds/kustomization.yaml -o .tmp/kustomization.yaml
 kubectl create -k .tmp
 
-echo "::debug::install istio crds"
+echo "[INFO] install istio crds"
 kubectl create -f https://raw.githubusercontent.com/istio/istio/1.22.0/manifests/charts/base/crds/crd-all.gen.yaml
 
-echo "::debug::install linkerd cli"
-curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install-edge | sh
+echo "[INFO] install linkerd crds via its cli"
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 curl --proto '=https' --tlsv1.2 -sSfL https://linkerd.github.io/linkerd-smi/install | sh
 export PATH=$PATH:$HOME/.linkerd2/bin/
 
@@ -18,11 +18,10 @@ echo "::debug::install linkerd crds via its cli"
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
 linkerd install --crds | kubectl apply -f -
 
-echo "::debug::GKE backendconfig crd"
+echo "[INFO] GKE backendconfig crd"
 kubectl create -f .github/workflows/scripts/chart-test-prep/backendconfigs.cloud.google.com.yaml
 
-echo "::debug::install prometheus operator crds"
-PROMETHEUS_CRDS_URL="https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/charts/crds/crds"
+echo "[INFO] install prometheus operator crds"
 kubectl create \
   -f "$PROMETHEUS_CRDS_URL/crd-alertmanagerconfigs.yaml" \
   -f "$PROMETHEUS_CRDS_URL/crd-alertmanagers.yaml" \
@@ -33,11 +32,11 @@ kubectl create \
   -f "$PROMETHEUS_CRDS_URL/crd-servicemonitors.yaml" \
   -f "$PROMETHEUS_CRDS_URL/crd-thanosrulers.yaml"
 
-echo "::debug::install canary CRD"
+echo "[INFO] install canary CRD"
 kubectl create -f https://raw.githubusercontent.com/fluxcd/flagger/main/artifacts/flagger/crd.yaml
 
-echo "::debug::apply chart preconditions"
+echo "[INFO] apply chart preconditions"
 kubectl apply -f .github/workflows/scripts/chart-test-prep/preconditions.yaml
 
-echo "::debug::install gateway crd"
+echo "[INFO] install gateway crd"
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml

--- a/.github/workflows/scripts/chart-test-prep.sh
+++ b/.github/workflows/scripts/chart-test-prep.sh
@@ -1,25 +1,28 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "[INFO] install flux crds"
+echo "::debug::install flux crds"
 mkdir -p .tmp
 curl -s https://raw.githubusercontent.com/fluxcd/flux2/main/manifests/crds/kustomization.yaml -o .tmp/kustomization.yaml
 kubectl create -k .tmp
 
-echo "[INFO] install istio crds"
+echo "::debug::install istio crds"
 kubectl create -f https://raw.githubusercontent.com/istio/istio/1.22.0/manifests/charts/base/crds/crd-all.gen.yaml
 
-echo "[INFO] install linkerd crds via its cli"
-curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
+echo "::debug::install linkerd cli"
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install-edge | sh
 curl --proto '=https' --tlsv1.2 -sSfL https://linkerd.github.io/linkerd-smi/install | sh
 export PATH=$PATH:$HOME/.linkerd2/bin/
+
+echo "::debug::install linkerd crds via its cli"
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
 linkerd install --crds | kubectl apply -f -
 
-echo "[INFO] GKE backendconfig crd"
+echo "::debug::GKE backendconfig crd"
 kubectl create -f .github/workflows/scripts/chart-test-prep/backendconfigs.cloud.google.com.yaml
 
-echo "[INFO] install prometheus operator crds"
+echo "::debug::install prometheus operator crds"
+PROMETHEUS_CRDS_URL="https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/charts/crds/crds"
 kubectl create \
   -f "$PROMETHEUS_CRDS_URL/crd-alertmanagerconfigs.yaml" \
   -f "$PROMETHEUS_CRDS_URL/crd-alertmanagers.yaml" \
@@ -30,11 +33,11 @@ kubectl create \
   -f "$PROMETHEUS_CRDS_URL/crd-servicemonitors.yaml" \
   -f "$PROMETHEUS_CRDS_URL/crd-thanosrulers.yaml"
 
-echo "[INFO] install canary CRD"
+echo "::debug::install canary CRD"
 kubectl create -f https://raw.githubusercontent.com/fluxcd/flagger/main/artifacts/flagger/crd.yaml
 
-echo "[INFO] apply chart preconditions"
+echo "::debug::apply chart preconditions"
 kubectl apply -f .github/workflows/scripts/chart-test-prep/preconditions.yaml
 
-echo "[INFO] install gateway crd"
+echo "::debug::install gateway crd"
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml

--- a/.github/workflows/scripts/chart-test-prep.sh
+++ b/.github/workflows/scripts/chart-test-prep.sh
@@ -13,8 +13,6 @@ echo "[INFO] install linkerd crds via its cli"
 curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
 curl --proto '=https' --tlsv1.2 -sSfL https://linkerd.github.io/linkerd-smi/install | sh
 export PATH=$PATH:$HOME/.linkerd2/bin/
-
-echo "::debug::install linkerd crds via its cli"
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
 linkerd install --crds | kubectl apply -f -
 


### PR DESCRIPTION
Follow GitHub best practice to pin actions using the full commit SHA.
See also:
- https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Requires
- https://github.com/MediaMarktSaturn/helm-charts/pull/199
