### PR TITLE
fix(scripts): fix linkerd install error in chart-test-prep

### DIFF
--- a/.github/workflows/scripts/chart-test-prep.sh
+++ b/.github/workflows/scripts/chart-test-prep.sh
@@ -1,39 +1,43 @@
 #!/bin/bash
 set -euo pipefail
 
-# install flux crds
+echo "::debug::install flux crds"
 mkdir -p .tmp
 curl -s https://raw.githubusercontent.com/fluxcd/flux2/main/manifests/crds/kustomization.yaml -o .tmp/kustomization.yaml
 kubectl create -k .tmp
 
-# install istio crds
+echo "::debug::install istio crds"
 kubectl create -f https://raw.githubusercontent.com/istio/istio/1.22.0/manifests/charts/base/crds/crd-all.gen.yaml
 
-# install linkerd crds via its cli
-curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
+echo "::debug::install linkerd cli"
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install-edge | sh
 curl --proto '=https' --tlsv1.2 -sSfL https://linkerd.github.io/linkerd-smi/install | sh
 export PATH=$PATH:$HOME/.linkerd2/bin/
+
+echo "::debug::install linkerd crds via its cli"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
 linkerd install --crds | kubectl apply -f -
 
-# GKE backendconfig crd
+echo "::debug::GKE backendconfig crd"
 kubectl create -f .github/workflows/scripts/chart-test-prep/backendconfigs.cloud.google.com.yaml
 
-# install prometheus operator crds
+echo "::debug::install prometheus operator crds"
+PROMETHEUS_CRDS_URL="https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/charts/crds/crds"
 kubectl create \
-  -f https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml \
-  -f https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagers.yaml \
-  -f https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/charts/crds/crds/crd-podmonitors.yaml \
-  -f https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/charts/crds/crds/crd-probes.yaml \
-  -f https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheuses.yaml \
-  -f https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml \
-  -f https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml \
-  -f https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/charts/crds/crds/crd-thanosrulers.yaml
+  -f "$PROMETHEUS_CRDS_URL/crd-alertmanagerconfigs.yaml" \
+  -f "$PROMETHEUS_CRDS_URL/crd-alertmanagers.yaml" \
+  -f "$PROMETHEUS_CRDS_URL/crd-podmonitors.yaml" \
+  -f "$PROMETHEUS_CRDS_URL/crd-probes.yaml" \
+  -f "$PROMETHEUS_CRDS_URL/crd-prometheuses.yaml" \
+  -f "$PROMETHEUS_CRDS_URL/crd-prometheusrules.yaml" \
+  -f "$PROMETHEUS_CRDS_URL/crd-servicemonitors.yaml" \
+  -f "$PROMETHEUS_CRDS_URL/crd-thanosrulers.yaml"
 
-# install canary CRD
+echo "::debug::install canary CRD"
 kubectl create -f https://raw.githubusercontent.com/fluxcd/flagger/main/artifacts/flagger/crd.yaml
 
-# apply chart preconditions
+echo "::debug::apply chart preconditions"
 kubectl apply -f .github/workflows/scripts/chart-test-prep/preconditions.yaml
 
-# install gateway crd
+echo "::debug::install gateway crd"
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml


### PR DESCRIPTION
Install gateway api required by linkerd to fix the error

```
Error: The Gateway API CRDs must be installed prior to installing
Linkerd: https://gateway-api.sigs.k8s.io/guides/#installing-gateway-api
```

Also replace the deprecated linkerd install url based on the message
in the workflow run
```
*******************************************
* This script is deprecated and no longer *
* installs stable releases.               *
*                                         *
* The latest edge release has been        *
* installed. In the future, please use    *
*   run.linkerd.io/install-edge           *
* for this behavior.                      *
*                                         *
* For stable releases, please see         *
*  https://linkerd.io/releases/           *
*******************************************
```

See also
- https://linkerd.io/2-edge/getting-started/#step-1-install-the-cli

Lastly replace comments in script with workflow debug messages
- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-debug-message

