### PR TITLE
chore(github): add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,47 @@
+---
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thank you for taking your time to fill out this bug report!
+        Please also search the [issues](https://github.com/MediaMarktSaturn/helm-charts/issues) first for similar issue before submitting a new one.
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: |
+        Tell us what should happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: |
+        Tell us what happens instead of the expected behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: |
+        Please provide a step by step instruction to reproduce this bug if applicable.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional Information
+      description: |
+        Include here any additional information, which you think are relevant to this bug.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+---
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,29 @@
+---
+name: Feature Request
+description: Request a new feature
+title: "[FEAT]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thank you for taking your time to fill out this form!
+        Please also search the [issues](https://github.com/MediaMarktSaturn/helm-charts/issues) first before submitting a new one.
+
+  - type: textarea
+    id: request-description
+    attributes:
+      label: Request Description
+      description: |
+        Tell us what should be improved/added/changed/removed and why you think it's necessary.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional Information
+      description: |
+        Include here any additional information, which you think are relevant to this request.
+    validations:
+      required: false

--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -1,0 +1,22 @@
+---
+name: "Assign issue"
+"on":
+  issues:
+    types:
+      - opened
+jobs:
+  add-comment:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: |
+          gh issue comment "$NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          BODY: |-
+            Thank you for taking your time to reach out. :heart:
+
+            @MediaMarktSaturn/gitops-crew :eyes:

--- a/.github/workflows/pr-chart-lint-and-test.yml
+++ b/.github/workflows/pr-chart-lint-and-test.yml
@@ -36,6 +36,8 @@ jobs:
             **/.*md
             .github/CODEOWNERS
             .github/dependabot.yml
+            .github/ISSUE_TEMPLATE/*
+            .github/workflows/assign_issue.yml
 
       - run: |
           echo "Has changes: ${{ steps.changed-files.outputs.any_changed }}"


### PR DESCRIPTION
Add templates for bug report and feature request, to guide users when
submitting new issues.
And add a workflow to thank the issue creator, plus mention the team
in a comment when new issue is opened.

See also:
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms
