### PR TITLE
ci(actions): remove setup-helm token input

### DIFF
--- a/.github/workflows/pr-chart-lint-and-test.yml
+++ b/.github/workflows/pr-chart-lint-and-test.yml
@@ -71,8 +71,6 @@ jobs:
           fetch-depth: 0
 
       - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:


### PR DESCRIPTION
This input has been removed with
- https://github.com/Azure/setup-helm/pull/131

See also the warning in one of the latest run
- https://github.com/MediaMarktSaturn/helm-charts/actions/runs/15031860812?pr=202
