### PR TITLE
feat(pod-cleanup): switch from bitnami to registry.k8s.io image

### DIFF
--- a/charts/pod-cleanup/Chart.yaml
+++ b/charts/pod-cleanup/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 maintainers:
   - name: MediaMarktSaturn
     url: https://github.com/MediaMarktSaturn
-version: 1.1.0
+version: 1.2.0

--- a/charts/pod-cleanup/README.md
+++ b/charts/pod-cleanup/README.md
@@ -16,8 +16,8 @@ Helm Chart for cleaning up failed/terminated Kubernetes pods
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image.repository | string | `"bitnami/kubectl"` |  |
-| image.tag | string | `"1.27"` |  |
+| image.repository | string | `"registry.k8s.io/kubectl"` |  |
+| image.tag | string | `"v1.34.1"` |  |
 | schedule | string | `"0 7 * * 1"` |  |
 | successfulJobsHistoryLimit | int | `3` |  |
 | failedJobsHistoryLimit | int | `3` |  |

--- a/charts/pod-cleanup/values.yaml
+++ b/charts/pod-cleanup/values.yaml
@@ -1,9 +1,9 @@
 image:
-  # Docker image used in container, defaults to https://hub.docker.com/r/bitnami/kubectl
+  # Docker image used in container, defaults to https://explore.ggcr.dev/?repo=registry.k8s.io%2Fkubectl
   # A different image can be used as long as it contains the "kubectl" tool
-  repository: bitnami/kubectl
+  repository: registry.k8s.io/kubectl
   # Tag can be set to any Kubernetes version, to avoid unexpected compability issues it is recommended to use the same version configured for the K8s cluster
-  tag: "1.27"
+  tag: "v1.34.1"
 
 # CronJob schedule https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax
 # Defaults to once every Monday on 07:00 AM (once per week)


### PR DESCRIPTION
The bitnami images are not widely available anymore. And existing tags
have been removed from DockerHub.
Therefore, switch to the official image from
- https://github.com/kubernetes/registry.k8s.io
