### PR TITLE
[Pod-Cleanup] Use args as there's no 'sh' in kubectl image

### DIFF
--- a/charts/pod-cleanup/Chart.yaml
+++ b/charts/pod-cleanup/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 maintainers:
   - name: MediaMarktSaturn
     url: https://github.com/MediaMarktSaturn
-version: 1.2.0
+version: 1.2.1

--- a/charts/pod-cleanup/templates/cronjob.yaml
+++ b/charts/pod-cleanup/templates/cronjob.yaml
@@ -28,10 +28,7 @@ spec:
           containers:
             - image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
               name: {{ $.Release.Name }}
-              command:
-                - /bin/sh
-                - -c
-                - kubectl delete pods -A --field-selector={{ $.Values.podFieldSelector }}
+              args: ["delete", "pods", "-A", "--field-selector={{ $.Values.podFieldSelector }}"]
               resources:
                 {{- toYaml $.Values.resources | nindent 16 }}
               imagePullPolicy: IfNotPresent


### PR DESCRIPTION
`error during container init: exec: "/bin/sh": stat /bin/sh: no such file or directory`