### PR TITLE
feat(application): allow to add annotations to deployment/statefulset

### DIFF
--- a/charts/application/Chart.yaml
+++ b/charts/application/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: MediaMarktSaturn
     url: https://github.com/MediaMarktSaturn
 appVersion: 1.0.0
-version: 1.35.0
+version: 1.36.0

--- a/charts/application/templates/k8s-deployment.yaml
+++ b/charts/application/templates/k8s-deployment.yaml
@@ -9,6 +9,9 @@ metadata:
   annotations:
     release/time: {{ date "2006-01-02T15:04:05Z07:00" now }}
     release/revision: {{ .Release.Revision | quote }}
+    {{- range $k, $v := .Values.annotations }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/application/templates/k8s-statefulset.yaml
+++ b/charts/application/templates/k8s-statefulset.yaml
@@ -9,6 +9,9 @@ metadata:
   annotations:
     release/time: {{ date "2006-01-02T15:04:05Z07:00" now }}
     release/revision: {{ .Release.Revision | quote }}
+    {{- range $k, $v := .Values.annotations }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -1,3 +1,6 @@
+# Additional annotations to be added to the created Deployment/Statefulset
+annotations: {}
+
 # per default, a Deployment is created, if required, it can be changed to a StatefulSet
 statefulSet:
   enabled: false


### PR DESCRIPTION
Some kubernetes controllers, for example reloader, use annotations
- https://github.com/stakater/Reloader#1--automatic-reload-default

on the Deployment/Statefulset to do their work.

Therefore, add a new key to application values to enable this.
