### PR TITLE
chore(actions): bump dependencies

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -21,7 +21,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
 
       - name: Generate docs
         run: .github/workflows/scripts/helm-docs.sh
@@ -41,7 +41,7 @@ jobs:
     needs:
       - release
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ref: gh-pages
@@ -50,7 +50,7 @@ jobs:
         run: git checkout origin/main -- README.md
 
       - name: Generate index.html from readme.md
-        uses: jaywcjlove/markdown-to-html-cli@d2c8ffd676de1801e2586904bc540a938e4bc480 # v5.0.3
+        uses: jaywcjlove/markdown-to-html-cli@cff9330af4ca8048b197a76d9eb1db189c2a7cee # v5.0.4
         with:
           source: README.md
           output: index.html
@@ -78,7 +78,7 @@ jobs:
     name: Generate helm docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -86,7 +86,7 @@ jobs:
         run: .github/workflows/scripts/helm-docs.sh
 
       - name: Create PR
-        uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7.0.9
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "docs: update versions in readme"
           author: github_actions <noreply@github.com>

--- a/.github/workflows/pr-chart-lint-and-test.yml
+++ b/.github/workflows/pr-chart-lint-and-test.yml
@@ -24,11 +24,11 @@ jobs:
       has_changes: ${{ steps.changed-files.outputs.any_changed }}
       matrix: ${{ steps.result.outputs.matrix }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
+      - uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
         id: changed-files
         with:
           files: |
@@ -51,10 +51,11 @@ jobs:
             echo "matrix<<EOF"
             echo '{ "include": ['
             [[ "${{ steps.changed-files.outputs.any_changed }}" == 'false' ]] && echo '{ "name": "lint" },'
-            echo '{ "name": "k8s-1.34", "kindest_image": "kindest/node:v1.34.0"  },'
-            echo '{ "name": "k8s-1.33", "kindest_image": "kindest/node:v1.33.4"  },'
-            echo '{ "name": "k8s-1.32", "kindest_image": "kindest/node:v1.32.8"  },'
-            echo '{ "name": "k8s-1.31", "kindest_image": "kindest/node:v1.31.12" }'
+            echo '{ "name": "k8s-1.35", "kindest_image": "kindest/node:v1.35.0"  },'
+            echo '{ "name": "k8s-1.34", "kindest_image": "kindest/node:v1.34.3"  },'
+            echo '{ "name": "k8s-1.33", "kindest_image": "kindest/node:v1.33.7"  },'
+            echo '{ "name": "k8s-1.32", "kindest_image": "kindest/node:v1.32.11" },'
+            echo '{ "name": "k8s-1.31", "kindest_image": "kindest/node:v1.31.14" }'
             echo '] }'
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
@@ -67,7 +68,7 @@ jobs:
     env:
       # See https://github.com/kubernetes-sigs/kind/releases
       # Check and update the image versions in the prep_job as well when updating this version.
-      kind_version: v0.30.0
+      kind_version: v0.31.0
       istio_version: 1.27.1
       k8s_sigs_gateway_version: v1.3.0
     strategy:
@@ -75,13 +76,13 @@ jobs:
       fail-fast: false
     name: ${{ matrix.name }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
 
-      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.python_version }}
 
@@ -91,7 +92,7 @@ jobs:
       - name: Lint charts
         run: ct lint --config .github/workflows/conf/ct-lint.yml
 
-      - uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1.13.0
+      - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           config: .github/workflows/conf/kind.yml
           version: ${{ env.kind_version }}
@@ -116,11 +117,11 @@ jobs:
     needs: prep_job
     if: ${{ needs.prep_job.outputs.has_changes == 'true' }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.python_version }}
 

--- a/.github/workflows/scripts/chart-test-prep.sh
+++ b/.github/workflows/scripts/chart-test-prep.sh
@@ -44,6 +44,6 @@ kubectl create -f https://raw.githubusercontent.com/fluxcd/flagger/main/artifact
 echo "::debug::apply chart preconditions"
 kubectl apply -f .github/workflows/scripts/chart-test-prep/preconditions.yaml
 
-echo "::debug::intall flux controllers"
+echo "::debug::install flux controllers"
 kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
 


### PR DESCRIPTION
- bump kind_version from 0.30.0 to 0.31.0
- bump actions/checkout from 6.0.1 to 6.0.2
- bump actions/setup-python from 6.1.0 to 6.2.0
- bump azure/setup-helm from 4.3.1 to 5.0.0
- bump helm/kind-action from 1.13.0 to 1.14.0
- bump jaywcjlove/markdown-to-html-cli from 5.0.3 to 5.0.4
- bump peter-evans/create-pull-request from 7.0.9 to 8.1.1
- bump tj-actions/changed-files from 47.0.0 to 47.0.5
